### PR TITLE
[RFR] Adding dependencies to compile C and C++ programs

### DIFF
--- a/recipes-images/kipr/kipr-console-image.bb
+++ b/recipes-images/kipr/kipr-console-image.bb
@@ -75,6 +75,12 @@ UTILITIES_INSTALL = " \
   git \
   cmake \
   llvm3.3 \
+  binutils \
+  glibc-dev \
+  libgcc-dev \
+  libstdc++-dev \
+  g++ \
+  g++-symlinks \
   gcc \
   gcc-symlinks \
   ckermit \


### PR DESCRIPTION
These tools and libraries make it possible to compile C and C++ programs against libwallaby on the device.
