### PR TITLE
[RFR] Switching co-processer from spi0.1 to spi1.0

### DIFF
--- a/recipes-kernel/linux/linux-kipr-3.17/0017-Now-using-spi1-for-coprocessor.patch
+++ b/recipes-kernel/linux/linux-kipr-3.17/0017-Now-using-spi1-for-coprocessor.patch
@@ -1,0 +1,39 @@
+--- a/arch/arm/boot/dts/am335x-pepper.dts
++++ b/arch/arm/boot/dts/am335x-pepper.dts
+@@ -395,11 +395,17 @@
+ 
+                 linux,wakeup;
+         };
++};
++
++&spi1 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi1_pins>;
+ 
+-	spibridge@1 {
+-                compatible = "spidev";
+-                reg = <1>;
+-                spi-max-frequency = <1500000>;
++	spibridge@0 {
++		compatible = "spidev";
++		reg = <0>;
++		spi-max-frequency = <1500000>;
+ 	};
+ };
+ 
+@@ -486,6 +492,14 @@
+ 			0x158 (PIN_INPUT_PULLUP | MUX_MODE0) /* spi0_d1.spi0_d1 */
+ 		>;
+ 	};
++	spi1_pins: pinmux_spi1 {
++		pinctrl-single,pins = <
++			0x190 (PIN_INPUT_PULLUP | MUX_MODE3) /* spi1_sclk.spi1_sclk */
++			0x19C (PIN_INPUT_PULLUP | MUX_MODE3) /* spi1_cs0.spi1_cs0 */
++			0x194 (PIN_INPUT_PULLUP | MUX_MODE3) /* spi1_d0.spi1_d0 */
++			0x198 (PIN_INPUT_PULLUP | MUX_MODE3) /* spi1_d1.spi1.d1 */
++		>;
++	};
+ 	ads7846_pins: pinmux_ads7846 {
+ 		pinctrl-single,pins = <
+ 			0x164 (PIN_INPUT | MUX_MODE7)	/* ecap0_in_pwm0_out.gpio0_7 */

--- a/recipes-kernel/linux/linux-kipr_3.17.bb
+++ b/recipes-kernel/linux/linux-kipr_3.17.bb
@@ -50,6 +50,7 @@ SRC_URI = " \
     file://0015-gpio-backlight-Discover-driver-during-boot-time.patch \
     file://0016-Fix-frequency-scaling-on-Gumstix-Pepper.patch \
     file://0001-Add-support-for-Botball-v2.patch \
+    file://0017-Now-using-spi1-for-coprocessor.patch \
     file://defconfig \
     file://${BOOT_SPLASH} \
 "


### PR DESCRIPTION
The latest board received 11.18.2018 is using SPI1 for communication to the co-processor (chip select 0).    Previously it was on SPI0 (chip select 1) along with the touch screen (child select 0).
