### PR TITLE
[RFR] prevent screen timeout, show boot info, rotate display 180

### DIFF
--- a/recipes-bsp/u-boot/u-boot/uEnv.txt
+++ b/recipes-bsp/u-boot/u-boot/uEnv.txt
@@ -1,2 +1,7 @@
 fdtfile=am335x-botball-lcd.dtb
 #fdtfile=am335x-botball-hdmi.dtb
+mpurate=auto
+dvimode="hd720 omapfb.vram=0:8M,1:4M,2:4M"
+vram=16M
+optargs="consoleblank=0 fbcon=rotate:2"
+console="tty0 console=ttyO0,115200n8"


### PR DESCRIPTION
This also shows the display during boot over HDMI (when HDMI is selected in uEnv.txt). Previously nothing was displayed until the log-in screen.
