### PR TITLE
[RFR] Bumping libwallaby version to get sig int catching for motor/servo cleanup

### DIFF
--- a/recipes-support/libwallaby/libwallaby_git.bb
+++ b/recipes-support/libwallaby/libwallaby_git.bb
@@ -1,9 +1,9 @@
 inherit cmake
 
 PN="libwallaby"
-PR="51"
+PR="55"
 
-SRCREV = "e7c1af41640cd925b87bb999b4a8f28b2f3f612e"
+SRCREV = "b9added3a73dbdfc9792e10cf6c9a551ef089302"
 
 SRC_URI="git://github.com/kipr/libwallaby.git;branch=master"
 


### PR DESCRIPTION
This turns the motors and servos off when a user ctrl-c's a program or stops if via the web runner.
