### PR TITLE
[RFR] Adding argument for wallaby_upgrade

### DIFF
--- a/recipes-support/wallaby-utility/files/wallaby_upgrade
+++ b/recipes-support/wallaby-utility/files/wallaby_upgrade
@@ -9,16 +9,16 @@ mkdir -p /media/usbdisk
 mount /dev/sda1 /media/usbdisk
 
 # Check arguments
-#NARGS_EXPECTED=1
-#if [ $# -ne 1 ];
-#then
-#	echo "Expected $NARGS_EXPECTED argument(s), got $#"
-#	exit
-#fi
+DEFAULT_BIN_PATH=/mnt/kipr-console-image-pepper.tar.bz2
+if [ $# -lt 1 ];
+then
+	echo "Expected upgrade image filepath as an argument, using default $DEFAULT_BIN_PATH"
+	BIN_PATH=$DEFAULT_BIN_PATH
+else
+	BIN_PATH=$1
+fi
 
 # look for expected files
-#BIN_PATH=$1
-BIN_PATH=/media/usbdisk/kipr-console-image-pepper.tar.bz2
 if [ ! -f $BIN_PATH ];
 then
 	echo "Expected upgrade binary file at $BIN_PATH"

--- a/recipes-support/wallaby-utility/wallaby-utility_1.0.bb
+++ b/recipes-support/wallaby-utility/wallaby-utility_1.0.bb
@@ -10,7 +10,7 @@ SRC_URI = "file://wallaby_upgrade \
            file://reset_coproc.service \
 "
 
-PR = "1.3"
+PR = "1.4"
 
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM="file://${WORKDIR}/LICENSE;md5=4fe869ee987a340198fb0d54c55c47f1"


### PR DESCRIPTION
Necessary for harrogate to pass an upgrade image filepath.
