### PR TITLE
[RFR] Add meta-nodejs to bblayers

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -21,6 +21,7 @@ BBLAYERS ?= " \
   ##COREBASE##/meta-ros \
   ##COREBASE##/meta-ti \
   ##COREBASE##/meta-browser \
+  ##COREBASE##/meta-nodejs \
   "
 
 BBMASK = "meta-ti/recipes-kernel"


### PR DESCRIPTION
This removes a step when setting up a bitbake build...  meta-nodejs will be added to `build/conf/bblayers.conf`
